### PR TITLE
add priority to config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 setup(
     name="windutil",
-    version="1.0.2",
+    version="1.0.3",
     install_requires=[
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 setup(
     name="windutil",
-    version="1.0.1",
+    version="1.0.2",
     install_requires=[
     ],
     entry_points={

--- a/windutil/argparser.py
+++ b/windutil/argparser.py
@@ -81,6 +81,20 @@ def _config_init(subparsers):
         return 'init', parg
     parser.set_defaults(func=up_fun)
 
+
+def _config_ps(subparsers):
+    ''' configure ps command '''
+    help_str = 'Get a terse view of statuses of running containers ' \
+               'configured in your ~/.wutilrc file'
+    parser = subparsers.add_parser('ps', help=help_str)
+    def up_fun(parg):
+        '''fun'''
+        return 'ps', parg
+    parser.set_defaults(func=up_fun)
+    help_str = 'show ALL containers, not just ~/.wutilrc configured ones.'
+    parser.add_argument('-a', '--all', default=False,
+                        action='store_true', help=help_str)
+
 def _config(command, help_str, subparsers, parent_parser):
     ''' configure command '''
     parser = subparsers.add_parser(command, help=help_str,
@@ -116,6 +130,7 @@ def parse():
     _config_run(subparsers, parent_parser)
     _config_upgrade(subparsers, parent_parser)
     _config_init(subparsers)
+    _config_ps(subparsers)
     #
     # process args
     #

--- a/windutil/main.py
+++ b/windutil/main.py
@@ -9,13 +9,14 @@ from windutil.scrlogger import ScrLogger
 
 LOG = ScrLogger()
 
-DEFAULT_CONTAINER_INFO={
-    'redis': {
+DEFAULT_CONTAINER_CONFIG=[
+    {
         'name'     : 'redis',
         'priority' : 0,
         'run'      : 'docker run --name wind_redis -p 6379 : 6379 -d redis',
-        'image'    : 'redis'}
-}
+        'image'    : 'redis'
+    }
+]
 
 CONFIG_FILE_PATH = os.path.expanduser('~') + '/.wutilrc'
 def _read_config():
@@ -26,12 +27,12 @@ def _read_config():
         LOG.debug("writing config to %s" % CONFIG_FILE_PATH)
         wutilrc.write(
             json.dumps(
-                DEFAULT_CONTAINER_INFO,
+                DEFAULT_CONTAINER_CONFIG,
                 sort_keys=True,
                 indent=4,
                 separators=(',', ': ')))
         wutilrc.close()
-        return DEFAULT_CONTAINER_INFO
+        return DEFAULT_CONTAINER_CONFIG
 
     LOG.debug("reading config from %s" % CONFIG_FILE_PATH)
     wutilrc = open(CONFIG_FILE_PATH, 'r')
@@ -39,7 +40,15 @@ def _read_config():
     wutilrc.close()
     return json.loads(json_str)
 
-CONTAINER_INFO= _read_config()
+def _load_config():
+    '''store by name for key'''
+    info = {}
+    for cntr in CONTAINER_CONFIG:
+        info[cntr['name']] = cntr
+    return info
+
+CONTAINER_CONFIG = _read_config()
+CONTAINER_INFO= _load_config()
 
 def _rm(pargs):
     '''rm'''

--- a/windutil/main.py
+++ b/windutil/main.py
@@ -10,9 +10,11 @@ from windutil.scrlogger import ScrLogger
 LOG = ScrLogger()
 
 DEFAULT_CONTAINER_INFO={
-    'wind_redis': {
-        'run': 'docker run --name wind_redis -p 6379:6379 -d redis',
-        'image': 'redis'}
+    'redis': {
+        'name'     : 'redis',
+        'priority' : 0,
+        'run'      : 'docker run --name wind_redis -p 6379 : 6379 -d redis',
+        'image'    : 'redis'}
 }
 
 CONFIG_FILE_PATH = os.path.expanduser('~') + '/.wutilrc'
@@ -103,6 +105,12 @@ def _ps(pargs):
             if pargs.all or cname in keys:
                 print line[status_idx:]
 
+def _sorted_config_names():
+    '''manage dependencies'''
+    newlist = sorted(CONTAINER_INFO.values(), key=lambda x: x['priority'],
+                     reverse=False)
+    return [x['name'] for x in newlist]
+
 def main():
     '''main entry point'''
     try:
@@ -114,7 +122,7 @@ def main():
             _ps(pargs)
             return
         if pargs.containers and pargs.containers[0] == 'all':
-            pargs.containers = CONTAINER_INFO.keys()
+            pargs.containers = _sorted_config_names()
         if cmd is 'start':
             _start(pargs)
         if cmd is 'stop':

--- a/windutil/main.py
+++ b/windutil/main.py
@@ -85,12 +85,33 @@ def _upgrade(pargs):
         _pull(pargs)
     _run(pargs)
 
+def _ps(pargs):
+    '''ps'''
+    option = '-a'
+    from subprocess import Popen, PIPE
+    process = Popen(["docker", "ps", option], stdout=PIPE)
+    (output, _) = process.communicate()
+    process.wait()
+    import string
+    lines = string.split(output, '\n')
+    status_idx = lines[0].index('STATUS')
+    print lines[0][status_idx:]
+    keys = CONTAINER_INFO.keys()
+    for line in lines[1:]:
+        if len(line) > 0:
+            cname = line[status_idx:].split()[-1]
+            if pargs.all or cname in keys:
+                print line[status_idx:]
+
 def main():
     '''main entry point'''
     try:
         cmd, pargs = parse()
         if cmd is 'init':
             print "Initialized"
+            return
+        if cmd is 'ps':
+            _ps(pargs)
             return
         if pargs.containers and pargs.containers[0] == 'all':
             pargs.containers = CONTAINER_INFO.keys()


### PR DESCRIPTION
- new config file format (breaks old configs)
  - the new format has a priority so you can start stuff in a specific order.  The app should propbably be able to figure it out from the link commands but if priority is based on anything else, that wouldn't be enough - thus the explicit config param.
- new ps command
